### PR TITLE
Update YamlDotNet and Microsoft.NET.Test.Sdk versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ BenchmarkDotNet v0.14.0, Windows 11 (10.0.22631.3958/23H2/2023Update/SunValley3)
 | 'YamlDotNet-based parser. File: example_small.yaml' | 73.380 us | 0.6213 us | 0.5508 us |  1.00 | 5.7373  | 0.6104  |  70.79 KB |        1.00 |
 ```
 
-YamlDotNet library version: 16.0.0
+YamlDotNet library version: 16.1.0
 
 ## License
 

--- a/src/SolidCode.Extensions.Configuration.Yaml.Benchmark/SolidCode.Extensions.Configuration.Yaml.Benchmark.csproj
+++ b/src/SolidCode.Extensions.Configuration.Yaml.Benchmark/SolidCode.Extensions.Configuration.Yaml.Benchmark.csproj
@@ -13,7 +13,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
-		<PackageReference Include="YamlDotNet" Version="16.0.0" />
+		<PackageReference Include="YamlDotNet" Version="16.1.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/SolidCode.Extensions.Configuration.Yaml.Tests/SolidCode.Extensions.Configuration.Yaml.Tests.csproj
+++ b/src/SolidCode.Extensions.Configuration.Yaml.Tests/SolidCode.Extensions.Configuration.Yaml.Tests.csproj
@@ -16,7 +16,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
 		<PackageReference Include="xunit" Version="2.9.0" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
 			<PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Updated README.md to reflect YamlDotNet version change from 16.0.0 to 16.1.0. Updated SolidCode.Extensions.Configuration.Yaml.Benchmark.csproj to reference YamlDotNet 16.1.0. Updated SolidCode.Extensions.Configuration.Yaml.Tests.csproj to reference Microsoft.NET.Test.Sdk 17.11.1.