### PR TITLE
Update project dependencies and target frameworks

### DIFF
--- a/.github/workflows/publish_development.yml
+++ b/.github/workflows/publish_development.yml
@@ -16,10 +16,15 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Setup .NET
+    - name: Setup .NET 8
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 8.0.x
+
+    - name: Setup .NET 9
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 9.0.x
 
     - name: Restore dependencies
       working-directory: ./src

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -14,10 +14,15 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Setup .NET
+    - name: Setup .NET 8
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 8.0.x
+
+    - name: Setup .NET 9
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 9.0.x
 
     - name: Restore dependencies
       working-directory: ./src

--- a/.github/workflows/run_test.yml
+++ b/.github/workflows/run_test.yml
@@ -15,10 +15,15 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Setup .NET
+    - name: Setup .NET 8
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 8.0.x
+
+    - name: Setup .NET 9
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 9.0.x
 
     - name: Restore dependencies
       working-directory: ./src

--- a/src/SolidCode.Extensions.Configuration.Yaml.Benchmark/SolidCode.Extensions.Configuration.Yaml.Benchmark.csproj
+++ b/src/SolidCode.Extensions.Configuration.Yaml.Benchmark/SolidCode.Extensions.Configuration.Yaml.Benchmark.csproj
@@ -13,7 +13,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
-		<PackageReference Include="YamlDotNet" Version="16.1.0" />
+		<PackageReference Include="YamlDotNet" Version="16.2.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/SolidCode.Extensions.Configuration.Yaml.Benchmark/YamlDotNetParser.cs
+++ b/src/SolidCode.Extensions.Configuration.Yaml.Benchmark/YamlDotNetParser.cs
@@ -6,7 +6,7 @@ using YamlDotNet.RepresentationModel;
 /// <summary>The configuration parser implementation using YamlDotNet.</summary>
 internal static class YamlDotNetParser
 {
-	private static readonly IDictionary<string, string?> _data = new SortedDictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+	private static readonly SortedDictionary<string, string?> _data = new SortedDictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
 	private static readonly Stack<string> _paths = new Stack<string>();
 	private static string _currentPath = string.Empty;
 

--- a/src/SolidCode.Extensions.Configuration.Yaml.Tests/SolidCode.Extensions.Configuration.Yaml.Tests.csproj
+++ b/src/SolidCode.Extensions.Configuration.Yaml.Tests/SolidCode.Extensions.Configuration.Yaml.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFrameworks>net8.0;net9.0</TargetFrameworks>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 
@@ -17,12 +17,12 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-		<PackageReference Include="xunit" Version="2.9.0" />
+		<PackageReference Include="xunit" Version="2.9.2" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/SolidCode.Extensions.Configuration.Yaml/SolidCode.Extensions.Configuration.Yaml.csproj
+++ b/src/SolidCode.Extensions.Configuration.Yaml/SolidCode.Extensions.Configuration.Yaml.csproj
@@ -1,15 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
-		<LangVersion>12.0</LangVersion>
+		<TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+		<LangVersion>13.0</LangVersion>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<DocumentationFile>bin\$(Configuration)\$(TargetFramework)\SolidCode.Extensions.Configuration.Yaml.xml</DocumentationFile>
 
 		<Title>SolidCode.Extensions.Configuration.Yaml</Title>
 		<Description>YAML configuration support for Microsoft.Extensions.Configuration.</Description>
-		<Version>0.9.3</Version>
+		<Version>0.10.0</Version>
 		<Copyright>©️ 2024 Andrey Veselov</Copyright>
 
 		<PackageId>SolidCode.Extensions.Configuration.Yaml</PackageId>
@@ -27,8 +27,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="8.0.1" />
+		<PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="9.0.0" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Updated `SolidCode.Extensions.Configuration.Yaml.Benchmark.csproj` to use `YamlDotNet` version `16.2.0` (from `16.1.0`).

Modified `SolidCode.Extensions.Configuration.Yaml.Tests.csproj` to target `net8.0` and `net9.0` (from `net8.0` only). Updated `xunit` to `2.9.2` (from `2.9.0`) and `Microsoft.Extensions.Hosting` to `9.0.0` (from `8.0.0`).

Updated `SolidCode.Extensions.Configuration.Yaml.csproj` to target `net8.0` and `net9.0` (from `net8.0` only). Updated language version to `13.0` (from `12.0`). Incremented project version to `0.10.0` (from `0.9.3`). Updated `Microsoft.Extensions.Configuration` to `9.0.0` (from `8.0.0`) and `Microsoft.Extensions.Configuration.FileExtensions` to `9.0.0` (from `8.0.1`).