### PR TITLE
Update xunit to v3 and add xunit.analyzers

### DIFF
--- a/src/SolidCode.Extensions.Configuration.Yaml.Tests/SolidCode.Extensions.Configuration.Yaml.Tests.csproj
+++ b/src/SolidCode.Extensions.Configuration.Yaml.Tests/SolidCode.Extensions.Configuration.Yaml.Tests.csproj
@@ -17,7 +17,8 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-		<PackageReference Include="xunit" Version="2.9.2" />
+		<PackageReference Include="xunit.v3" Version="1.0.0" />
+		<PackageReference Include="xunit.analyzers" Version="1.18.0" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.0.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Upgraded the xunit package from version 2.9.2 to xunit.v3 version 1.0.0. Added a new package reference for xunit.analyzers version 1.18.0 to enhance static analysis of xUnit tests in SolidCode.Extensions.Configuration.Yaml.Tests.csproj.