### PR TITLE
Upgrade dependencies

### DIFF
--- a/src/SolidCode.Extensions.Configuration.Yaml.Benchmark/SolidCode.Extensions.Configuration.Yaml.Benchmark.csproj
+++ b/src/SolidCode.Extensions.Configuration.Yaml.Benchmark/SolidCode.Extensions.Configuration.Yaml.Benchmark.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 
@@ -12,7 +12,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
+		<PackageReference Include="BenchmarkDotNet" Version="0.15.1" />
 		<PackageReference Include="YamlDotNet" Version="16.3.0" />
 	</ItemGroup>
 

--- a/src/SolidCode.Extensions.Configuration.Yaml.Tests/SolidCode.Extensions.Configuration.Yaml.Tests.csproj
+++ b/src/SolidCode.Extensions.Configuration.Yaml.Tests/SolidCode.Extensions.Configuration.Yaml.Tests.csproj
@@ -12,18 +12,21 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="coverlet.collector" Version="6.0.2">
+		<PackageReference Include="coverlet.collector" Version="6.0.4">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-		<PackageReference Include="xunit.v3" Version="1.0.0" />
-		<PackageReference Include="xunit.analyzers" Version="1.18.0" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="3.0.0">
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+		<PackageReference Include="xunit.v3" Version="2.0.3" />
+		<PackageReference Include="xunit.analyzers" Version="1.22.0">
+		  <PrivateAssets>all</PrivateAssets>
+		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.6" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/SolidCode.Extensions.Configuration.Yaml/SolidCode.Extensions.Configuration.Yaml.csproj
+++ b/src/SolidCode.Extensions.Configuration.Yaml/SolidCode.Extensions.Configuration.Yaml.csproj
@@ -9,7 +9,7 @@
 
 		<Title>SolidCode.Extensions.Configuration.Yaml</Title>
 		<Description>YAML configuration support for Microsoft.Extensions.Configuration.</Description>
-		<Version>0.10.0</Version>
+		<Version>0.10.1</Version>
 		<Copyright>©️ 2024 Andrey Veselov</Copyright>
 
 		<PackageId>SolidCode.Extensions.Configuration.Yaml</PackageId>

--- a/src/SolidCode.Extensions.Configuration.Yaml/SolidCode.Extensions.Configuration.Yaml.csproj
+++ b/src/SolidCode.Extensions.Configuration.Yaml/SolidCode.Extensions.Configuration.Yaml.csproj
@@ -27,8 +27,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="9.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.6" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="9.0.6" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
- Changed target framework from net8.0 to net9.0 in SolidCode.Extensions.Configuration.Yaml.Benchmark.csproj.
- Upgraded BenchmarkDotNet from 0.14.0 to 0.15.1.
- Updated coverlet.collector from 6.0.2 to 6.0.4 in SolidCode.Extensions.Configuration.Yaml.Tests.csproj.
- Upgraded Microsoft.NET.Test.Sdk from 17.12.0 to 17.14.1.
- Updated xunit.v3 from 1.0.0 to 2.0.3.
- Upgraded xunit.analyzers from 1.18.0 to 1.22.0.
- Updated xunit.runner.visualstudio from 3.0.0 to 3.1.1.
- Upgraded Microsoft.Extensions.Hosting from 9.0.0 to 9.0.6.
- Updated Microsoft.Extensions.Configuration from 9.0.0 to 9.0.6.
- Updated Microsoft.Extensions.Configuration.FileExtensions from 9.0.0 to 9.0.6.