### PR TITLE
Add .NET 8 and 9 setup to CI workflows

### DIFF
--- a/.github/workflows/publish_development.yml
+++ b/.github/workflows/publish_development.yml
@@ -16,6 +16,16 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - name: Setup .NET 8
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 8.0.x
+
+    - name: Setup .NET 9
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 9.0.x
+
     - name: Setup .NET 10
       uses: actions/setup-dotnet@v4
       with:

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -14,6 +14,16 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - name: Setup .NET 8
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 8.0.x
+
+    - name: Setup .NET 9
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 9.0.x
+
     - name: Setup .NET 10
       uses: actions/setup-dotnet@v4
       with:

--- a/.github/workflows/run_test.yml
+++ b/.github/workflows/run_test.yml
@@ -15,6 +15,16 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - name: Setup .NET 8
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 8.0.x
+
+    - name: Setup .NET 9
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 9.0.x
+
     - name: Setup .NET 10
       uses: actions/setup-dotnet@v4
       with:


### PR DESCRIPTION
Added steps to set up .NET 8.0.x and 9.0.x SDKs alongside .NET 10.0.x in publish_development.yml, publish_release.yml, and run_test.yml. This ensures all three .NET versions are available in the CI environment for builds and tests.