### PR TITLE
Add .NET 8 and 9 SDK setup to CI workflows

### DIFF
--- a/.github/workflows/publish_development.yml
+++ b/.github/workflows/publish_development.yml
@@ -16,6 +16,16 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - name: Setup .NET 8
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 8.0.x
+
+    - name: Setup .NET 9
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 9.0.x
+
     - name: Setup .NET 10
       uses: actions/setup-dotnet@v4
       with:

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -14,6 +14,16 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - name: Setup .NET 8
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 8.0.x
+
+    - name: Setup .NET 9
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 9.0.x
+
     - name: Setup .NET 10
       uses: actions/setup-dotnet@v4
       with:

--- a/.github/workflows/run_test.yml
+++ b/.github/workflows/run_test.yml
@@ -15,6 +15,16 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - name: Setup .NET 8
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 8.0.x
+
+    - name: Setup .NET 9
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 9.0.x
+
     - name: Setup .NET 10
       uses: actions/setup-dotnet@v4
       with:


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to add support for .NET 8 and .NET 9 in addition to the existing .NET 10 setup. These changes ensure that our CI/CD pipelines can build, test, and publish using multiple .NET versions, improving compatibility and future-proofing our workflows.

**Workflow updates for multi-version .NET support:**

* Added steps to set up .NET 8 and .NET 9 in the `publish_development.yml` workflow, alongside the existing .NET 10 setup.
* Added steps to set up .NET 8 and .NET 9 in the `publish_release.yml` workflow, alongside the existing .NET 10 setup.
* Added steps to set up .NET 8 and .NET 9 in the `run_test.yml` workflow, alongside the existing .NET 10 setup.